### PR TITLE
Fixed GLSL compilation issues, and wrong references to preferences

### DIFF
--- a/addon_updater_ops.py
+++ b/addon_updater_ops.py
@@ -23,7 +23,7 @@ import os
 # updater import, import safely
 # Prevents popups for users with invalid python installs e.g. missing libraries
 try:
-    from .addon_updater import Updater as updater
+    from addon_updater import Updater as updater
 except Exception as e:
     print("ERROR INITIALIZING UPDATER")
     print(str(e))
@@ -154,7 +154,7 @@ class ADDON_OP_addon_updater_check_now(bpy.types.Operator):
             return {'CANCELLED'}
 
         # apply the UI settings
-        settings = context.user_preferences.addons[__package__].preferences
+        settings = context.preferences.addons[__package__].preferences
         updater.set_check_interval(enable=settings.auto_check_update,
                                    months=settings.updater_intrval_months,
                                    days=settings.updater_intrval_days,
@@ -627,7 +627,7 @@ def check_for_update_background():
         return
 
     # apply the UI settings
-    addon_prefs = bpy.context.user_preferences.addons.get(__package__, None)
+    addon_prefs = bpy.context.preferences.addons.get(__package__, None)
     if not addon_prefs:
         return
     settings = addon_prefs.preferences
@@ -657,7 +657,7 @@ def check_for_update_nonthreaded(self, context):
     # only check if it's ready, ie after the time interval specified
     # should be the async wrapper call here
 
-    settings = context.user_preferences.addons[__package__].preferences
+    settings = context.preferences.addons[__package__].preferences
     updater.set_check_interval(enable=settings.auto_check_update,
                                months=settings.updater_intrval_months,
                                days=settings.updater_intrval_days,
@@ -730,7 +730,7 @@ def update_notice_box_ui(self, context):
 
     if updater.update_ready != True: return
 
-    settings = context.user_preferences.addons[__package__].preferences
+    settings = context.preferences.addons[__package__].preferences
     layout = self.layout
     box = layout.box()
     col = box.column(align=True)
@@ -763,7 +763,7 @@ def update_settings_ui(self, context):
         box.label(updater.error_msg)
         return
 
-    settings = context.user_preferences.addons[__package__].preferences
+    settings = context.preferences.addons[__package__].preferences
 
     # auto-update settings
     box.label("Updater Settings")

--- a/sprytile_gui.py
+++ b/sprytile_gui.py
@@ -29,10 +29,11 @@ flat_vertex_shader = '''
 
 flat_fragment_shader = '''
     in vec4 o_color;
+    out vec4 frag_color;
 
     void main()
     {
-        gl_FragColor = o_color;
+        frag_color = o_color;
     }
 '''
 
@@ -55,10 +56,11 @@ image_fragment_shader = '''
     uniform sampler2D u_image;
 
     in vec2 o_uv;
+    out vec4 frag_color;
 
     void main()
     {
-        gl_FragColor = texture(u_image, o_uv);
+        frag_color = texture(u_image, o_uv);
     }
 '''
 
@@ -288,7 +290,7 @@ class VIEW3D_OP_SprytileGui(bpy.types.Operator):
             VIEW3D_OP_SprytileGui.cursor_grid_pos = grid_pos
 
             if event.type == 'LEFTMOUSE' and event.value == 'PRESS' and VIEW3D_OP_SprytileGui.is_selecting is False:
-                addon_prefs = context.user_preferences.addons[__package__].preferences
+                addon_prefs = context.preferences.addons[__package__].preferences
                 move_mod_pressed = False
                 if addon_prefs.tile_sel_move_key == 'Alt':
                     move_mod_pressed = event.alt
@@ -739,7 +741,7 @@ class VIEW3D_OP_SprytileGui(bpy.types.Operator):
                 return
             screen_verts.append(screen_vtx)
 
-        addon_prefs = context.user_preferences.addons[__package__].preferences
+        addon_prefs = context.preferences.addons[__package__].preferences
         preview_alpha = addon_prefs.preview_transparency
         sprytile_data = context.scene.sprytile_data
 

--- a/sprytile_modal.py
+++ b/sprytile_modal.py
@@ -714,7 +714,7 @@ class VIEW3D_OP_SprytileModalTool(bpy.types.Operator):
         elif scene.sprytile_data.cursor_snap == 'VERTEX':
             # Get if user is holding down tile picker modifier
             check_modifier = False
-            addon_prefs = context.user_preferences.addons[__package__].preferences
+            addon_prefs = context.preferences.addons[__package__].preferences
             if addon_prefs.tile_picker_key == 'Alt':
                 check_modifier = event.alt
             if addon_prefs.tile_picker_key == 'Ctrl':
@@ -897,7 +897,7 @@ class VIEW3D_OP_SprytileModalTool(bpy.types.Operator):
         elif event.type == 'LEFTMOUSE':
             check_modifier = False
             # TODO: Support preferences
-            #addon_prefs = context.user_preferences.addons[__package__].preferences
+            #addon_prefs = context.preferences.addons[__package__].preferences
             #if addon_prefs.tile_picker_key == 'Alt':
             #    check_modifier = event.alt
             #if addon_prefs.tile_picker_key == 'Ctrl':

--- a/sprytile_utils.py
+++ b/sprytile_utils.py
@@ -1651,7 +1651,7 @@ class VIEW3D_PT_SprytileWorkflowPanel(bpy.types.Panel):
         sub_row.prop(data, "axis_plane_display", expand=True)
 
         if data.axis_plane_settings:
-            addon_prefs = context.user_preferences.addons[__package__].preferences
+            addon_prefs = context.preferences.addons[__package__].preferences
             layout.prop(addon_prefs, "preview_transparency")
             layout.prop(data, "axis_plane_color")
             layout.prop(data, "axis_plane_size")


### PR DESCRIPTION
Hi, I fixed a few issues related to used this addon on Mac OS Catalina

1.- The GLSL shader does not compile, the problem is the variable **gl_FragColor** that is not supported anymore, so i moved to an out var.

2.- In the latest version of blender the correct name for **user_preferences** seems to be just **preferences**.

3.- There was an error trying to import the package **addon_updater**, i just removed the relative reference and it worked fine